### PR TITLE
Mention NaN handling in dtype description

### DIFF
--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -169,7 +169,7 @@ General Parsing Configuration
 dtype : Type name or dict of column -> type, default ``None``
   Data type for data or columns. E.g. ``{'a': np.float64, 'b': np.int32}``
   (unsupported with ``engine='python'``). Use `str` or `object` together
-  with suitable `na_values` settings to preserve and
+  with suitable ``na_values`` settings to preserve and
   not interpret dtype.
 
   .. versionadded:: 0.20.0 support for the Python parser.

--- a/doc/source/io.rst
+++ b/doc/source/io.rst
@@ -168,7 +168,8 @@ General Parsing Configuration
 
 dtype : Type name or dict of column -> type, default ``None``
   Data type for data or columns. E.g. ``{'a': np.float64, 'b': np.int32}``
-  (unsupported with ``engine='python'``). Use `str` or `object` to preserve and
+  (unsupported with ``engine='python'``). Use `str` or `object` together
+  with suitable `na_values` settings to preserve and
   not interpret dtype.
 
   .. versionadded:: 0.20.0 support for the Python parser.

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -125,8 +125,8 @@ mangle_dupe_cols : boolean, default True
     are duplicate names in the columns.
 dtype : Type name or dict of column -> type, default None
     Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32}
-    Use `str` or `object` together with passing `keep_default_na=False` and
-    `na_values` to preserve and not interpret dtype.
+    Use `str` or `object` together with suitable `na_values` settings
+    to preserve and not interpret dtype.
     If converters are specified, they will be applied INSTEAD
     of dtype conversion.
 %s

--- a/pandas/io/parsers.py
+++ b/pandas/io/parsers.py
@@ -125,7 +125,8 @@ mangle_dupe_cols : boolean, default True
     are duplicate names in the columns.
 dtype : Type name or dict of column -> type, default None
     Data type for data or columns. E.g. {'a': np.float64, 'b': np.int32}
-    Use `str` or `object` to preserve and not interpret dtype.
+    Use `str` or `object` together with passing `keep_default_na=False` and
+    `na_values` to preserve and not interpret dtype.
     If converters are specified, they will be applied INSTEAD
     of dtype conversion.
 %s


### PR DESCRIPTION
To achieve preservation and avoid interpretation of string or object dtypes, NaN value interpretation must be switched off.

- [x] closes issue #20875
- [ ] build test passed
- [ ] `pandas.read_csv.html` renders text as intended


